### PR TITLE
Bump `ghostwriter/clock` from `3.0.0` to `3.0.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,11 @@
         "composer-plugin-api": "^2.6.0",
         "composer-runtime-api": "^2.2.2",
         "nikic/php-parser": "^5.4.0",
-        "rector/rector": "^2.0"
+        "rector/rector": "^2.0.6"
     },
     "require-dev": {
         "ghostwriter/case-converter": "^1.0.0",
-        "ghostwriter/clock": "^3.0.0",
+        "ghostwriter/clock": "^3.0",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "^0.4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24e3970992a0f5e112750418962adb0f",
+    "content-hash": "e87ce449cd224a0075b03d36ae40534e",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -896,16 +896,16 @@
         },
         {
             "name": "ghostwriter/clock",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/clock.git",
-                "reference": "906ded66d7dda723531aa7b0d3554f9026304d3b"
+                "reference": "e68368475feb957b7d40e3d1e03de411fe6b032d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/clock/zipball/906ded66d7dda723531aa7b0d3554f9026304d3b",
-                "reference": "906ded66d7dda723531aa7b0d3554f9026304d3b",
+                "url": "https://api.github.com/repos/ghostwriter/clock/zipball/e68368475feb957b7d40e3d1e03de411fe6b032d",
+                "reference": "e68368475feb957b7d40e3d1e03de411fe6b032d",
                 "shasum": ""
             },
             "require": {
@@ -913,12 +913,12 @@
             },
             "require-dev": {
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/psalm-plugin": "^0.2.0"
+                "ghostwriter/psalm-plugin": "dev-main"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Ghostwriter\\Clock\\": "src"
+                    "Ghostwriter\\Clock\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -940,8 +940,6 @@
                 "ghostwriter"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/clock",
-                "forum": "https://github.com/ghostwriter/clock/discussions",
                 "issues": "https://github.com/ghostwriter/clock/issues",
                 "rss": "https://github.com/ghostwriter/clock/releases.atom",
                 "security": "https://github.com/ghostwriter/clock/security/advisories/new",
@@ -953,7 +951,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-21T23:42:37+00:00"
+            "time": "2025-01-05T19:26:41+00:00"
         },
         {
             "name": "ghostwriter/coding-standard",


### PR DESCRIPTION
Bumps `ghostwriter/clock` from `3.0.0` to `3.0.1`.

- Update `composer.json`
- Update `composer.lock`