### PR TITLE
Bump `rector/rector` from `2.0.6` to `2.0.7`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,11 @@
         "composer-plugin-api": "^2.6.0",
         "composer-runtime-api": "^2.2.2",
         "nikic/php-parser": "^5.4.0",
-        "rector/rector": "^2.0.6"
+        "rector/rector": "^2.0.7"
     },
     "require-dev": {
         "ghostwriter/case-converter": "^1.0.0",
-        "ghostwriter/clock": "^3.0",
+        "ghostwriter/clock": "^3.0.1",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "^0.4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e87ce449cd224a0075b03d36ae40534e",
+    "content-hash": "670f50822e1086f0017ae35e711b441b",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -124,16 +124,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.0.6",
+            "version": "2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "fa0cb009dc3df084bf549032ae4080a0481a2036"
+                "reference": "e70d681f6a0c361a63e6825897cd97746436f015"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/fa0cb009dc3df084bf549032ae4080a0481a2036",
-                "reference": "fa0cb009dc3df084bf549032ae4080a0481a2036",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e70d681f6a0c361a63e6825897cd97746436f015",
+                "reference": "e70d681f6a0c361a63e6825897cd97746436f015",
                 "shasum": ""
             },
             "require": {
@@ -171,7 +171,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.0.6"
+                "source": "https://github.com/rectorphp/rector/tree/2.0.7"
             },
             "funding": [
                 {
@@ -179,7 +179,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-06T10:38:36+00:00"
+            "time": "2025-01-19T09:41:28+00:00"
         }
     ],
     "packages-dev": [
@@ -5120,7 +5120,7 @@
         "composer-plugin-api": "^2.6.0",
         "composer-runtime-api": "^2.2.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3.999"
     },


### PR DESCRIPTION
Bumps `rector/rector` from `2.0.6` to `2.0.7`.

- Update `composer.json`
- Update `composer.lock`