### PR TITLE
Bump `ghostwriter/uuid` from `1.0.1` to `1.0.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "ghostwriter/psalm-plugin": "dev-main",
         "ghostwriter/result": "^1.3.0",
         "ghostwriter/shell": "^0.1.0",
-        "ghostwriter/uuid": "^1.0.1",
+        "ghostwriter/uuid": "^1.0.2",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^11.5.3",
         "symfony/var-dumper": "^7.2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a539b8cb2fd17265111cae00703bd56",
+    "content-hash": "48244e7b19e7f26e15fa4eebfb8ffe1d",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -1714,16 +1714,16 @@
         },
         {
             "name": "ghostwriter/uuid",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/uuid.git",
-                "reference": "bece9c34ccf981fc65150cde0087cd5af57c6603"
+                "reference": "0867b6c92d5e2973c87ad13f88aae66f39ce7dd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/uuid/zipball/bece9c34ccf981fc65150cde0087cd5af57c6603",
-                "reference": "bece9c34ccf981fc65150cde0087cd5af57c6603",
+                "url": "https://api.github.com/repos/ghostwriter/uuid/zipball/0867b6c92d5e2973c87ad13f88aae66f39ce7dd6",
+                "reference": "0867b6c92d5e2973c87ad13f88aae66f39ce7dd6",
                 "shasum": ""
             },
             "require": {
@@ -1731,7 +1731,8 @@
                 "php": ">=8.3"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main"
+                "ghostwriter/coding-standard": "dev-main",
+                "ghostwriter/handrail": "dev-main"
             },
             "type": "library",
             "autoload": {
@@ -1758,8 +1759,6 @@
                 "uuid"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/uuid",
-                "forum": "https://github.com/ghostwriter/uuid/discussions",
                 "issues": "https://github.com/ghostwriter/uuid/issues",
                 "rss": "https://github.com/ghostwriter/uuid/releases.atom",
                 "security": "https://github.com/ghostwriter/uuid/security/advisories/new",
@@ -1771,7 +1770,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-21T21:08:22+00:00"
+            "time": "2025-01-28T18:15:13+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Bumps `ghostwriter/uuid` from `1.0.1` to `1.0.2`.

- Update `composer.json`
- Update `composer.lock`